### PR TITLE
Potential enhancement to NMF mult

### DIFF
--- a/neighbors/_fit.py
+++ b/neighbors/_fit.py
@@ -143,9 +143,14 @@ def mult(X, W, H, data_range, eps, tol, n_iterations, verbose):
                 tol,
             )
 
-        # Update H
-        numer = W.T @ X
-        denom = W.T @ W @ H + eps
+        # The np.multiply's below have the effect of only using observed (non-missing)
+        # ratings when performing the factor matrix updates
+
+        # NOTE: Current issue seems to be that this *dramatically over-fits* compared to just filling in missing values with 0. Training RMSE goes way down < 1%, but testing RMSE increases substantially because some predictions aren't even on the right scale! This seems to be dataset dependent as this binary masking works decently well for other datasets. Triple-checked the implementation, but can't see to figure out why this occurs for some data and not others. All I can see if that for the datasets in which it occurs, the item x factor matrix is usually almost all 0s, with a few exceptionally large values (in the thousands). Try 'BestOfTimes' from the moth dataset as an example
+
+        # Update H (factor x item)
+        numer = W.T @ np.multiply(M, X)
+        denom = W.T @ np.multiply(M, W @ H) + eps
         H *= numer
         H /= denom
 


### PR DESCRIPTION
This tries to use the approach in [Blondel et al](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.89.3109&rep=rep1&type=pdf) and [Zhu, 16](https://paperpile.com/shared/CY1jfi) for using a weight/mask matrix to ignore missing values while doing the Lee & Seung multiplicative update. The latter implementation can be found in a git repo [here](https://github.com/guangtunbenzhu/NonnegMFPy/blob/master/NonnegMFPy/nmf.py)

It initially seemed to work well for some data where out-of-sample performance increased, but for other data it performed horrendously where predictions weren't even on the same scale as the user ratings. Given how finicky it seems to be, I've unmerged it from master and I'm leaving it in this branch/PR for posterity. 

